### PR TITLE
Allow link to show Daly on the map

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -22,6 +22,7 @@ export function getMapLink(location) {
         "Graham": 205,
         "Guadalupe": 230,
         "Kenna": 33,
+        "Daly": 16,
         "Learning Commons": 144,
         "Leavey": 37,
         "Locatelli": 156,


### PR DESCRIPTION
The rooms don't work properly but it's better than not having a map at all