### PR TITLE
Fix vulnerability in email checking

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -241,7 +241,7 @@ export async function getUserPerms(user) {
 
     myRoles.push(defaultRole);
     const email = user.providerData[0].email;
-    if (email.includes("@scu.edu") || email.includes("@alumni.scu.edu")){
+    if (email.endsWith("@scu.edu") || email.endsWith("@alumni.scu.edu")){
         myRoles.push(scuRole)
     }
 

--- a/src/layout/MainNavbar.vue
+++ b/src/layout/MainNavbar.vue
@@ -288,7 +288,7 @@ export default {
       if (user) {
         // console.log("Signed in", user);
         const email = user.providerData[0].email;
-        if (email.includes("@scu.edu") || email.includes("@alumni.scu.edu")){
+        if (email.endsWith("@scu.edu") || email.endsWith("@alumni.scu.edu")){
             const userName = user.displayName;
             const uid = user.uid;
 


### PR DESCRIPTION
By using "includes", we were vulnerable to subdomain exploits. e.g. test@scu.edu.example.com would be able to login.